### PR TITLE
Allow custom error transformation on GraphQLEngine #119 #120 (#122)

### DIFF
--- a/src/GraphQL.Conventions/Adapters/Engine/ErrorTransformations/DefaultErrorTransformation.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/ErrorTransformations/DefaultErrorTransformation.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using GraphQL.Conventions.Execution;
+
+namespace GraphQL.Conventions.Adapters.Engine.ErrorTransformations
+{
+    public class DefaultErrorTransformation : IErrorTransformation
+    {
+        public ExecutionErrors Transform(ExecutionErrors errors)
+            => errors.Aggregate(new ExecutionErrors(), (result, executionError) =>
+            {
+                var exception = new FieldResolutionException(executionError);
+                var error = new ExecutionError(exception.Message, exception);
+                foreach (var location in executionError.Locations ?? Enumerable.Empty<ErrorLocation>())
+                {
+                    error.AddLocation(location.Line, location.Column);
+                }
+                error.Path = executionError.Path;
+                result.Add(error);
+                return result;
+            });
+    }
+}

--- a/src/GraphQL.Conventions/Adapters/Engine/ErrorTransformations/IErrorTransformation.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/ErrorTransformations/IErrorTransformation.cs
@@ -1,0 +1,7 @@
+﻿namespace GraphQL.Conventions.Adapters.Engine.ErrorTransformations
+{
+    public interface IErrorTransformation
+    {
+        ExecutionErrors Transform(ExecutionErrors errors);
+    }
+}

--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Conventions.Adapters;
+using GraphQL.Conventions.Adapters.Engine.ErrorTransformations;
 using GraphQL.Conventions.Adapters.Engine.Listeners.DataLoader;
 using GraphQL.Conventions.Builders;
 using GraphQL.Conventions.Execution;
@@ -43,6 +44,8 @@ namespace GraphQL.Conventions
         List<System.Type> _schemaTypes = new List<System.Type>();
 
         List<System.Type> _middleware = new List<System.Type>();
+
+        IErrorTransformation _errorTransformation = new DefaultErrorTransformation();
 
         bool _includeFieldDescriptions;
 
@@ -171,6 +174,12 @@ namespace GraphQL.Conventions
             return WithMiddleware(typeof(T));
         }
 
+        public GraphQLEngine WithCustomErrorTransformation(IErrorTransformation errorTransformation)
+        {
+            _errorTransformation = errorTransformation;
+            return this;
+        }
+
         public GraphQLEngine PrintFieldDescriptions(bool include = true)
         {
             _includeFieldDescriptions = include;
@@ -283,21 +292,9 @@ namespace GraphQL.Conventions
 
             var result = await _documentExecutor.ExecuteAsync(configuration).ConfigureAwait(false);
 
-            if (result.Errors != null)
+            if (result.Errors != null && _errorTransformation != null)
             {
-                var errors = new ExecutionErrors();
-                foreach (var executionError in result.Errors)
-                {
-                    var exception = new FieldResolutionException(executionError);
-                    var error = new ExecutionError(exception.Message, exception);
-                    foreach (var location in executionError.Locations ?? new ErrorLocation[0])
-                    {
-                        error.AddLocation(location.Line, location.Column);
-                    }
-                    error.Path = executionError.Path;
-                    errors.Add(error);
-                }
-                result.Errors = errors;
+                result.Errors = _errorTransformation.Transform(result.Errors);
             }
 
             return result;

--- a/test/Tests/Adapters/Engine/CustomErrorTransformationTests.cs
+++ b/test/Tests/Adapters/Engine/CustomErrorTransformationTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Conventions;
+using GraphQL.Conventions.Adapters.Engine.ErrorTransformations;
+using GraphQL.Conventions.Execution;
+using GraphQL.Conventions.Tests;
+using GraphQL.Conventions.Tests.Templates;
+using GraphQL.Conventions.Tests.Templates.Extensions;
+
+namespace Tests.Adapters.Engine
+{
+    public class CustomErrorTransformationTests : TestBase
+    {
+        [Test]
+        public async Task Will_Use_Default_Error_Transformation_When_Not_Provided()
+        {
+            var engine = GraphQLEngine.New<Query>();
+            var result = await engine
+                .NewExecutor()
+                .WithQueryString("query { queryData }")
+                .Execute();
+
+            result.Errors.ShouldNotBeNull();
+            result.Errors.Count.ShouldEqual(1);
+            var error = result.Errors.First();
+            error.ShouldBeOfType<ExecutionError>();
+            error.InnerException.ShouldBeOfType<FieldResolutionException>();
+            error.InnerException.InnerException.ShouldBeOfType<CustomException>();
+        }
+
+        [Test]
+        public async Task Will_Use_Custom_Error_Transformation_When_Provided()
+        {
+            var engine = GraphQLEngine.New<Query>();
+            var result = await engine
+                .WithCustomErrorTransformation(new CustomErrorTransformation())
+                .NewExecutor()
+                .WithQueryString("query { queryData }")
+                .Execute();
+
+            result.Errors.ShouldNotBeNull();
+            result.Errors.Count.ShouldEqual(1);
+            var error = result.Errors.First();
+            error.ShouldBeOfType<ExecutionError>();
+            error.InnerException.ShouldBeOfType<TargetInvocationException>();
+            error.InnerException.InnerException.ShouldBeOfType<CustomException>();
+        }
+
+        class Query
+        {
+            public string QueryData() => throw new CustomException();
+        }
+
+        class CustomErrorTransformation : IErrorTransformation
+        {
+            public ExecutionErrors Transform(ExecutionErrors errors)
+                => errors;
+        }
+
+        class CustomException : Exception { }
+    }
+}

--- a/test/Tests/Templates/Extensions/TestExtensions.cs
+++ b/test/Tests/Templates/Extensions/TestExtensions.cs
@@ -79,6 +79,11 @@ namespace GraphQL.Conventions.Tests.Templates.Extensions
             str.ShouldContain(substring);
         }
 
+        public static void ShouldBeOfType<T>(this object actual)
+        {
+            Assert.IsInstanceOfType(actual, typeof(T));
+        }
+
         public static void ShouldBeNamed(this GraphEntityInfo entity, string name)
         {
             entity.Name.ShouldEqual(name);

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit.runner.reporters" Version="2.3.1" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="NSubstitute" Version="2.0.0-*" />
     <PackageReference Include="ReportGenerator" Version="2.5.9" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
* Allow custom error transformation on GraphQLEngine

* Make IErrorTransformation.Transform syncrhonous

* Use Enumerable.Empty instead of creating empty array